### PR TITLE
Fix/workaround issues with Rasa connection to A2A server in `docker-compose` setup on EC2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ actions/__pycache__/
 tracker
 .cache
 .config
+*.DS_store*

--- a/car-purchase-assistant/README.md
+++ b/car-purchase-assistant/README.md
@@ -104,6 +104,10 @@ directory.
 
 ### Running the Assistant
 
+#### Either, with `docker compose`
+ - Run `docker compose up`
+
+#### Or, *without* `docker compose`:
 To run the car purchase assistant, follow these steps in order:
 
 1. **Start the Web Search MCP server**

--- a/car-purchase-assistant/docker-compose.yml
+++ b/car-purchase-assistant/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - 'inspect'
       - '--endpoints'
       - 'endpoints-docker-compose.yml'
+      - '--sub-agents'
+      - 'sub_agents_docker_compose'
       - '--debug'
     ports:
       - '5005:5005'
@@ -35,6 +37,8 @@ services:
       - '--enable-api'
       - '--endpoints'
       - 'endpoints-docker-compose.yml'
+      - '--sub-agents'
+      - 'sub_agents_docker_compose'
       - '--debug'
     ports:
       - '5006:5005'
@@ -79,16 +83,29 @@ services:
       - '8002:8002'
 
   car_shopping_a2a_agent_server:
+    depends_on:
+      - car_shopping_a2a_agent_server_init_container
     container_name: car_shopping_A2A_agent_server
     build:
       context: ./servers/car_shopping_server
       dockerfile: Dockerfile
     command:
       - 'car_shopping_server.py'
+      - '--host'
+      - '0.0.0.0'
     ports: 
       - '10002:10002'
     environment:
       - GOOGLE_API_KEY=${GOOGLE_API_KEY}
+
+  # Workaround for bug ENG-2253, whereby custom `--sub-agent` directory not being used,
+  # so copying over directory (including required A2A agent card) via init container 
+  car_shopping_a2a_agent_server_init_container:
+    image: alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
+    volumes:
+      - ./sub_agents:/app/sub_agents
+      - ./sub_agents_docker_compose:/app/sub_agents_docker_compose
+    command: "sh -c 'rm -rf /app/sub_agents/* && cp -r /app/sub_agents_docker_compose/* /app/sub_agents'"
 
 volumes:
   db:

--- a/car-purchase-assistant/sub_agents_docker_compose/shopping_agent/agent_card.json
+++ b/car-purchase-assistant/sub_agents_docker_compose/shopping_agent/agent_card.json
@@ -1,7 +1,7 @@
 {
   "name": "Car Shopping Agent",
   "description": "This agent helps users shop for cars by connecting them with dealers and facilitating purchases",
-  "url": "http://car_shopping_A2A_agent_server:10002/",
+  "url": "http://car_shopping_A2A_agent_server:10002",
   "version": "1.0.0",
   "defaultInputModes": ["text", "text/plain"],
   "defaultOutputModes": ["text", "text/plain", "application/json"],


### PR DESCRIPTION
I noticed following issues when reproducing the issue (of a2a agent flow getting cancelled) locally:
1. [ENG-2253](https://rasahq.atlassian.net/browse/ENG-2253): Agent-card still getting loaded from default directory, when custom directory is provided. This was contributing to connection error, as agent URL in default agent card does not work for the docker-compose setup.
    - To workaround, using an init container to copy over required files to default `sub_agents` directory for now.
 2. By default `car_shopping_server` starts on localhost, which was causing connection issue* in docker compose setup, so starting server on `0.0.0.0` in docker.
     - *This issue wasn't fully apparent earlier due to bug [ENG-2254](https://rasahq.atlassian.net/browse/ENG-2254) whereby successful connection message was being incorrectly shown

[ENG-2253]: https://rasahq.atlassian.net/browse/ENG-2253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-2254]: https://rasahq.atlassian.net/browse/ENG-2254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ